### PR TITLE
Get occupancy to articulated

### DIFF
--- a/ReachLib/include/articulated.hpp
+++ b/ReachLib/include/articulated.hpp
@@ -16,6 +16,7 @@ GNU General Public License for more details: https://www.gnu.org/licenses/.
 #include <string>
 #include <utility>
 #include <vector>
+#include <memory>
 
 #include "body_part.hpp"
 #include "capsule.hpp"
@@ -91,6 +92,12 @@ class Articulated : public Obstacle {
   virtual std::string get_mode() const {
     std::cout << "\n" << "Got error!" << "\n";
     throw "Function safety_perimeters::articulated::Articulated::get_mode is not defined!";
+  }
+
+  //! \brief Returns the current occupancy as a list of occupancy pointers
+  virtual std::vector<std::shared_ptr<Occupancy>> get_occupancy_p() const {
+    std::cout << "\n" << "Got error!" << "\n";
+    throw "Function safety_perimeters::articulated::Articulated::get_occupancy_p is not defined!";
   }
 
   //! \brief Returns the map of body segments and joint pairs

--- a/ReachLib/include/articulated_accel.hpp
+++ b/ReachLib/include/articulated_accel.hpp
@@ -88,6 +88,15 @@ class ArticulatedAccel : public Articulated {
     return this->occupancy_;
   }
 
+  //! \brief Returns the current occupancy as a list of body parts pointers
+  std::vector<std::shared_ptr<Occupancy>> get_occupancy_p() const override {
+    std::vector<std::shared_ptr<Occupancy>> occupancy;
+    for (const auto& item : this->occupancy_) {
+      occupancy.push_back(std::make_shared<BodyPartAccel>(item));
+    }
+    return occupancy;
+  }
+
  private:
   //! \brief Contains the most recent state of all occupancy segments
   std::vector<BodyPartAccel> occupancy_ = {};

--- a/ReachLib/include/articulated_combined.hpp
+++ b/ReachLib/include/articulated_combined.hpp
@@ -84,6 +84,15 @@ class ArticulatedCombined : public Articulated {
     return occupancy_;
   }
 
+  //! \brief Returns the current occupancy as a list of body parts pointers
+  std::vector<std::shared_ptr<Occupancy>> get_occupancy_p() const override {
+    std::vector<std::shared_ptr<Occupancy>> occupancy;
+    for (const auto& item : this->occupancy_) {
+      occupancy.push_back(std::make_shared<BodyPartCombined>(item));
+    }
+    return occupancy;
+  }
+
  private:
   //! \brief Contains the most recent state of all occupancy segments
   std::vector<BodyPartCombined> occupancy_ = {};

--- a/ReachLib/include/articulated_pos.hpp
+++ b/ReachLib/include/articulated_pos.hpp
@@ -89,6 +89,15 @@ class ArticulatedPos : public Articulated {
     return this->occupancy_;
   }
 
+  //! \brief Returns the current occupancy as a list of body parts pointers
+  std::vector<std::shared_ptr<Occupancy>> get_occupancy_p() const override {
+    std::vector<std::shared_ptr<Occupancy>> occupancy;
+    for (const auto& item : this->occupancy_) {
+      occupancy.push_back(std::make_shared<Extremity>(item));
+    }
+    return occupancy;
+  }
+
  private:
   //! \brief Contains the current occupancy
   std::vector<Extremity> occupancy_;

--- a/ReachLib/include/articulated_vel.hpp
+++ b/ReachLib/include/articulated_vel.hpp
@@ -16,6 +16,7 @@ GNU General Public License for more details: https://www.gnu.org/licenses/.
 #include <string>
 #include <utility>
 #include <vector>
+#include <memory>
 
 #include "articulated.hpp"
 #include "body_part_vel.hpp"
@@ -80,6 +81,15 @@ class ArticulatedVel : public Articulated {
   //! \brief Returns the current occupancy as a list of body parts
   std::vector<BodyPartVel> get_occupancy() const {
     return this->occupancy_;
+  }
+
+  //! \brief Returns the current occupancy as a list of body parts pointers
+  std::vector<std::shared_ptr<Occupancy>> get_occupancy_p() const override {
+    std::vector<std::shared_ptr<Occupancy>> occupancy;
+    for (const auto& item : this->occupancy_) {
+      occupancy.push_back(std::make_shared<BodyPartVel>(item));
+    }
+    return occupancy;
   }
 
  private:

--- a/ReachLib/include/body_part.hpp
+++ b/ReachLib/include/body_part.hpp
@@ -56,17 +56,9 @@ class BodyPart : public Occupancy {
     return occupancy_;
   }
 
-  //! \brief Returns the thickness of the body part
-  double get_thickness() const {
-      return thickness_;
-  }
-
  protected:
   //! \brief Contains the current occupancy
   Capsule occupancy_ = Capsule();
-
-  //! \brief Thickness of the body part
-  double thickness_;
 };
 }  // namespace body_parts
 }  //  namespace occupancies

--- a/ReachLib/include/extremity.hpp
+++ b/ReachLib/include/extremity.hpp
@@ -74,11 +74,6 @@ class Extremity : public Occupancy {
     return occupancy_;
   }
 
-  //! \brief Returns the thickness of the extremity
-  double get_thickness() const {
-      return thickness_;
-  }
-
   //! \brief Returns the length of the extremity
   double get_length() const {
       return length_;
@@ -87,9 +82,6 @@ class Extremity : public Occupancy {
  private:
   //! \brief Conains the current occupancy
   Capsule occupancy_ = Capsule();
-
-  //! \brief Thickness of the extremity
-  double thickness_ = 0.0;
 
   //! \brief Length of the extremity
   double length_ = 0.0;

--- a/ReachLib/include/occupancy.hpp
+++ b/ReachLib/include/occupancy.hpp
@@ -41,8 +41,11 @@ class Occupancy {
   //! \brief Empty costructor
   Occupancy() {}
 
-  //! \brief Initializes a named object of underterined type among Occupancys
+  //! \brief Initializes a named object of underterined type among Occupancies
   explicit Occupancy(std::string name);
+
+  //! \brief Initializes a named object of underterined type among Occupancies
+  explicit Occupancy(std::string name, double thickness);
 
   //! \brief Empty destructor
   virtual ~Occupancy() {}
@@ -83,12 +86,20 @@ class Occupancy {
       return this->name_;
   }
 
+  //! \brief Returns the thickness of the body part
+  double get_thickness() const {
+      return thickness_;
+  }
+
  protected:
   //! \brief Points to the current occupancy (for dynamic cast purposes)
   OccupancyContainer* occupancy_p = NULL;
 
   //! \brief A name that defines this occupancy
   std::string name_ = "";
+
+  //! \brief Thickness of the occupancy
+  double thickness_ = 0.0;
 };
 }  //  namespace occupancies
 #endif  // REACH_LIB_INCLUDE_OCCUPANCY_MODEL_HPP_

--- a/ReachLib/include/reach_lib.hpp
+++ b/ReachLib/include/reach_lib.hpp
@@ -90,8 +90,7 @@ typedef obstacles::pedestrian::vel::PedestrianVel PedestrianVel;
 
 inline std::vector<Capsule> get_capsules(const ArticulatedCombined& a_comb) {
   std::vector<Capsule> capsules;
-  std::vector<BodyPartCombined> occupancy = a_comb.get_occupancy();
-  for (const auto& it : occupancy) {
+  for (const auto& it : a_comb.get_occupancy()) {
     capsules.push_back(it.get_occupancy());
   }
   return capsules;

--- a/ReachLib/src/body_part.cpp
+++ b/ReachLib/src/body_part.cpp
@@ -27,7 +27,7 @@ BodyPart::BodyPart() : Occupancy() {
   this->occupancy_p = &this->occupancy_;
 }
 
-BodyPart::BodyPart(std::string name, double thickness) : thickness_(thickness), Occupancy(name) {
+BodyPart::BodyPart(std::string name, double thickness) : Occupancy(name, thickness) {
   //  NO TODO
 }
 }  // namespace body_parts

--- a/ReachLib/src/extremity.cpp
+++ b/ReachLib/src/extremity.cpp
@@ -31,8 +31,7 @@ Extremity::Extremity() : Occupancy() {
 
 Extremity::Extremity(std::string name, double thickness,
                      double length, double max_v) :
-                     thickness_(thickness), length_(length),
-                     max_v_(max_v), Occupancy(name) {
+                     length_(length), max_v_(max_v), Occupancy(name, thickness) {
   //  NO TODO
 }
 

--- a/ReachLib/src/occupancy.cpp
+++ b/ReachLib/src/occupancy.cpp
@@ -24,4 +24,8 @@ namespace occupancies {
 Occupancy::Occupancy(std::string name) : name_(name) {
   // NO TODO
 }
+
+Occupancy::Occupancy(std::string name, double thickness) : name_(name), thickness_(thickness) {
+  // NO TODO
+}
 }  // namspace occupancies


### PR DESCRIPTION
This PR enables you to get the occupancy of an abstract Articulated object and the thickness of an abstract occupancy. This is useful, when you don't know the type of Articulated / Occupancy at build time.